### PR TITLE
add: post read api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,11 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.projectlombok:lombok:1.18.22'
+	compileOnly 'org.projectlombok:lombok:1.18.26'
+	annotationProcessor 'org.projectlombok:lombok:1.18.26'
+
+	testCompileOnly 'org.projectlombok:lombok:1.18.26'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.26'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/javalot/ohwoonwan/controller/MainController.java
+++ b/src/main/java/com/javalot/ohwoonwan/controller/MainController.java
@@ -51,12 +51,13 @@ public class MainController {
     @GetMapping(path="/allUsers")
     public @ResponseBody Iterable<User> getAllUsers() {
         // This returns a JSON or XML with the users
+        System.out.println("users");
         return userRepository.findAll();
     }
 
     @GetMapping(path="/allPosts")
-    public @ResponseBody Iterable<Post> getAllPosts() {
-        return postRepository.findAll();
+    public JsonResult getAllPosts() {
+        return JsonResult.ok(postRepository.findAll());
     }
 
     @GetMapping(path="/allUsers/v2")

--- a/src/main/java/com/javalot/ohwoonwan/controller/PostController.java
+++ b/src/main/java/com/javalot/ohwoonwan/controller/PostController.java
@@ -1,0 +1,26 @@
+package com.javalot.ohwoonwan.controller;
+
+import com.javalot.ohwoonwan.model.JsonResult;
+import com.javalot.ohwoonwan.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PostController {
+    private final PostService postService;
+
+    @GetMapping("post/{id}")
+    public JsonResult findById(@PathVariable Long id) {
+        return JsonResult.ok(postService.findById(id));
+    }
+
+    @GetMapping("/posts")
+    public JsonResult findAllDesc() {
+        return JsonResult.ok(postService.findAllDesc());
+    }
+
+}

--- a/src/main/java/com/javalot/ohwoonwan/domain/Post.java
+++ b/src/main/java/com/javalot/ohwoonwan/domain/Post.java
@@ -5,25 +5,29 @@ import lombok.*;
 
 
 @Entity
-@AllArgsConstructor
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @Getter
-@Setter
 @ToString
+@Table(name = "post")
 public class Post extends TimestampEntity {
+    @Builder
     public Post(String category, String title, String content, User creator) {
-        super();
         this.category = category;
         this.title = title;
         this.content = content;
         this.createdBy = creator;
     }
-    public Post() {}
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 
     @Id
-    @GeneratedValue(strategy= GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Setter(AccessLevel.PROTECTED)
-    private Integer id;
+    private Long id;
 
     private String category;
     private String title;

--- a/src/main/java/com/javalot/ohwoonwan/domain/TimestampEntity.java
+++ b/src/main/java/com/javalot/ohwoonwan/domain/TimestampEntity.java
@@ -9,10 +9,10 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class TimestampEntity {
-    @Column(name = "`create_at`", nullable = false, updatable = false)
+    @Column(name = "`created_at`", nullable = false, updatable = false)
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime createdAt = LocalDateTime.now();
-    @Column(name = "`update_at`")
+    @Column(name = "`updated_at`")
     @Temporal(TemporalType.TIMESTAMP)
     @LastModifiedBy
     private LocalDateTime updatedAt;

--- a/src/main/java/com/javalot/ohwoonwan/domain/User.java
+++ b/src/main/java/com/javalot/ohwoonwan/domain/User.java
@@ -9,9 +9,10 @@ import org.hibernate.annotations.ColumnDefault;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @Getter
-@Setter
 @ToString
+@Table(name = "user")
 public class User extends TimestampEntity {
+    @Builder
     public User(String name, String nickName, String phone, String password, String email, Boolean gender, Boolean isAdmin) {
         super();
         this.name = name;

--- a/src/main/java/com/javalot/ohwoonwan/dto/PostListResponseDto.java
+++ b/src/main/java/com/javalot/ohwoonwan/dto/PostListResponseDto.java
@@ -1,0 +1,24 @@
+package com.javalot.ohwoonwan.dto;
+
+import com.javalot.ohwoonwan.domain.Post;
+import com.javalot.ohwoonwan.domain.User;
+import lombok.Getter;
+
+@Getter
+public class PostListResponseDto {
+    private Long id;
+    private String category;
+    private String title;
+    private String content;
+    private Integer view;
+    private User created_by;
+
+    public PostListResponseDto(Post entity) {
+        this.id = entity.getId();
+        this.category = entity.getCategory();
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.view = entity.getView();
+        this.created_by = entity.getCreatedBy();
+    }
+}

--- a/src/main/java/com/javalot/ohwoonwan/dto/PostResponseDto.java
+++ b/src/main/java/com/javalot/ohwoonwan/dto/PostResponseDto.java
@@ -1,0 +1,25 @@
+package com.javalot.ohwoonwan.dto;
+
+import com.javalot.ohwoonwan.domain.Post;
+import com.javalot.ohwoonwan.domain.User;
+import lombok.Getter;
+
+@Getter
+public class PostResponseDto {
+
+    private Long id;
+    private String category;
+    private String title;
+    private String content;
+    private Integer view;
+    private User created_by;
+
+    public PostResponseDto(Post entity) {
+        this.id = entity.getId();
+        this.category = entity.getCategory();
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.view = entity.getView();
+        this.created_by = entity.getCreatedBy();
+    }
+}

--- a/src/main/java/com/javalot/ohwoonwan/model/ExceptionAdvice.java
+++ b/src/main/java/com/javalot/ohwoonwan/model/ExceptionAdvice.java
@@ -1,0 +1,19 @@
+package com.javalot.ohwoonwan.model;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class ExceptionAdvice {
+
+    // 400 Bad Request
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> BadRequestException(final RuntimeException ex) {
+        log.error("error", ex);
+        return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+
+}

--- a/src/main/java/com/javalot/ohwoonwan/repository/PostRepository.java
+++ b/src/main/java/com/javalot/ohwoonwan/repository/PostRepository.java
@@ -1,11 +1,15 @@
 package com.javalot.ohwoonwan.repository;
 
 import com.javalot.ohwoonwan.domain.Post;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 // This will be AUTO IMPLEMENTED by Spring into a Bean called userRepository
 // CRUD refers Create, Read, Update, Delete
 
-public interface PostRepository extends CrudRepository<Post, Integer> {
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findAllByOrderByIdDesc();
 
 }

--- a/src/main/java/com/javalot/ohwoonwan/repository/UserRepository.java
+++ b/src/main/java/com/javalot/ohwoonwan/repository/UserRepository.java
@@ -1,10 +1,12 @@
 package com.javalot.ohwoonwan.repository;
 
+import java.util.List;
 import org.springframework.data.repository.CrudRepository;
 import com.javalot.ohwoonwan.domain.User;
 
 // This will be AUTO IMPLEMENTED by Spring into a Bean called userRepository
 // CRUD refers Create, Read, Update, Delete
+
 
 public interface UserRepository extends CrudRepository<User, Integer> {
 

--- a/src/main/java/com/javalot/ohwoonwan/service/PostService.java
+++ b/src/main/java/com/javalot/ohwoonwan/service/PostService.java
@@ -1,0 +1,13 @@
+package com.javalot.ohwoonwan.service;
+
+import com.javalot.ohwoonwan.dto.PostListResponseDto;
+import com.javalot.ohwoonwan.dto.PostResponseDto;
+
+import java.util.List;
+
+
+public interface PostService {
+    public PostResponseDto findById(Long id);
+    public List<PostListResponseDto> findAllDesc();
+
+}

--- a/src/main/java/com/javalot/ohwoonwan/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/javalot/ohwoonwan/service/impl/PostServiceImpl.java
@@ -1,0 +1,34 @@
+package com.javalot.ohwoonwan.service.impl;
+
+import com.javalot.ohwoonwan.domain.Post;
+import com.javalot.ohwoonwan.dto.PostListResponseDto;
+import com.javalot.ohwoonwan.dto.PostResponseDto;
+import com.javalot.ohwoonwan.repository.PostRepository;
+import com.javalot.ohwoonwan.service.PostService;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostServiceImpl implements PostService {
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public PostResponseDto findById(Long id) {
+        Post post = postRepository.findById(id).orElseThrow
+                (() -> new IllegalArgumentException("Not found post id = " + id));
+        return new PostResponseDto(post);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostListResponseDto> findAllDesc() {
+        return postRepository.findAllByOrderByIdDesc().stream()
+                .map(PostListResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
### 수정사항
1. API생성
  - posts 전체 글 read api 
  - post/{id} 단건 글 read api
2. entity 보호 및 분리를 위한 dto 생성
3. service 추상화
4. exceptionAdvice를 이용한 예외처리


### 공유사항
1. 기존에 pk값을 Integer로 타입을 지정했었는데 Long으로 많이 사용하는 것 같아서 Long으로 변경했습니다. - *스프링 부트와 AWS로 혼자 구현하는 웹 서비스책에 Long을 권장한다고 나온다고 하네요:)*
2. Entity(domain) 클래스에서 @Setter 대신 @builder를 통해 제공되는 빌더 클래스를 사용한다고 하여 setter는 삭제했습니다.
5. gradle 버전에 따라 lombok의존성 추가 방식이 달라 gradle 7.6버전에 맞는 방식으로 변경했습니다.
혹시나 하위 버전을 사용하신다면(특히나 gradle 5.x버전 미만) gradle 업데이트 부탁드립니다!
6. 세부 기능은 추후 추가 예정입니다!